### PR TITLE
Add missing @return type declarations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -133,16 +133,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.44",
+            "version": "0.12.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "330b45776ea77f167b150e24787412414a8fa469"
+                "reference": "b8248f9c81265af75d6d969ca3252aaf3e998f3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/330b45776ea77f167b150e24787412414a8fa469",
-                "reference": "330b45776ea77f167b150e24787412414a8fa469",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b8248f9c81265af75d6d969ca3252aaf3e998f3a",
+                "reference": "b8248f9c81265af75d6d969ca3252aaf3e998f3a",
                 "shasum": ""
             },
             "require": {
@@ -185,7 +185,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-24T15:28:47+00:00"
+            "time": "2020-10-16T12:22:23+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -280,16 +280,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v5.1.5",
+            "version": "v5.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "e7d37c91486a0f9eed58a8c23822e1870ea36db5"
+                "reference": "150aeb91dd9dafe13ec8416abd62e435330ca12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/e7d37c91486a0f9eed58a8c23822e1870ea36db5",
-                "reference": "e7d37c91486a0f9eed58a8c23822e1870ea36db5",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/150aeb91dd9dafe13ec8416abd62e435330ca12d",
+                "reference": "150aeb91dd9dafe13ec8416abd62e435330ca12d",
                 "shasum": ""
             },
             "require": {
@@ -297,6 +297,9 @@
             },
             "conflict": {
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0|<6.4,>=6.0|9.1.2"
+            },
+            "require-dev": {
+                "symfony/deprecation-contracts": "^2.1"
             },
             "suggest": {
                 "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
@@ -355,7 +358,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-01T13:16:17+00:00"
+            "time": "2020-10-02T12:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -133,16 +133,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.50",
+            "version": "0.12.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b8248f9c81265af75d6d969ca3252aaf3e998f3a"
+                "reference": "e96dd5e7ae9aefed663bc7e285ad96792b67eadc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b8248f9c81265af75d6d969ca3252aaf3e998f3a",
-                "reference": "b8248f9c81265af75d6d969ca3252aaf3e998f3a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e96dd5e7ae9aefed663bc7e285ad96792b67eadc",
+                "reference": "e96dd5e7ae9aefed663bc7e285ad96792b67eadc",
                 "shasum": ""
             },
             "require": {
@@ -185,20 +185,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-16T12:22:23+00:00"
+            "time": "2020-10-25T07:23:44+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.6",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -236,7 +236,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-08-10T04:50:15+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "stevegrunwell/runkit7-installer",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,8 +3,5 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
-        # PHPUnit framework classes are provided by symfony/phpunit-bridge.
-        -
-            message: '#^Class PHPUnit\\Framework\\.+ not found\.$#'
-            path: *
+    scanDirectories:
+        - vendor/bin/.phpunit/phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,7 @@
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
+    <php>
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1" />
+    </php>
 </phpunit>

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -55,6 +55,8 @@ trait Constants
      *
      * @param string $name  The constant name.
      * @param mixed  $value The scalar value to store in the constant.
+     *
+     * @return self
      */
     protected function setConstant($name, $value = null)
     {
@@ -86,6 +88,8 @@ trait Constants
      * Delete a constant.
      *
      * @param string $name The constant name.
+     *
+     * @return self
      */
     protected function deleteConstant($name)
     {

--- a/src/EnvironmentVariables.php
+++ b/src/EnvironmentVariables.php
@@ -37,6 +37,8 @@ trait EnvironmentVariables
      * @param string $variable The environment variable name.
      * @param mixed  $value    The value to store in the environment variable. Passing NULL will
      *                         delete the environment variable.
+     *
+     * @return self
      */
     protected function setEnvironmentVariable($variable, $value = null)
     {
@@ -53,6 +55,8 @@ trait EnvironmentVariables
      * Delete an environment variable.
      *
      * @param string $variable The variable name.
+     *
+     * @return self
      */
     protected function deleteEnvironmentVariable($variable)
     {

--- a/src/GlobalVariables.php
+++ b/src/GlobalVariables.php
@@ -42,6 +42,8 @@ trait GlobalVariables
      * @param string $variable The global variable name.
      * @param mixed  $value    The new, temporary value. Passing NULL will unset the given
      *                         $variable, if it exists.
+     *
+     * @return self
      */
     protected function setGlobalVariable($variable, $value)
     {

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -31,7 +31,7 @@ class ConstantsTest extends TestCase
      */
     public function setConstant_should_be_able_to_handle_newly_defined_constants()
     {
-        $this->requiresRunkit('This test depends on runkit being unavailable.');
+        $this->requiresRunkit('This test depends on runkit being available.');
 
         $this->assertFalse(defined('SOME_CONSTANT'));
 
@@ -48,7 +48,7 @@ class ConstantsTest extends TestCase
      */
     public function setConstant_should_be_able_to_redefine_existing_constants()
     {
-        $this->requiresRunkit('This test depends on runkit being unavailable.');
+        $this->requiresRunkit('This test depends on runkit being available.');
 
         $this->setConstant('EXISTING_CONSTANT', 'some other value');
         $this->assertSame('some other value', constant('EXISTING_CONSTANT'));
@@ -67,7 +67,7 @@ class ConstantsTest extends TestCase
      */
     public function setConstant_should_throw_an_exception_if_it_cannot_redefine_a_constant()
     {
-        $this->requiresRunkit('This test depends on runkit being unavailable.');
+        $this->requiresRunkit('This test depends on runkit being available.');
 
         $this->expectException(RedefineException::class);
         $this->setConstant('EXISTING_CONSTANT', (object) ['some' => 'object']);
@@ -85,7 +85,7 @@ class ConstantsTest extends TestCase
      */
     public function deleteConstant_should_remove_an_existing_constant()
     {
-        $this->requiresRunkit('This test depends on runkit being unavailable.');
+        $this->requiresRunkit('This test depends on runkit being available.');
 
         $this->deleteConstant('DELETE_THIS_CONSTANT');
         $this->assertFalse(defined('DELETE_THIS_CONSTANT'));


### PR DESCRIPTION
When removing the type-hints for the sake of PHP 5.6 compatibility, I failed to add `@return` docblock tags to the methods.

Additionally, fixed a wording issue with `requiresRunkit()` calls: the tests depend on runkit being *available*, not *unavailable*.