### PR TITLE
Introduce a Runkit support class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
             "@test:analysis"
         ],
         "test:analysis": [
-            "phpstan analyse"
+            "simple-phpunit --version",
+            "phpstan analyse -c phpstan.neon.dist"
         ],
         "test:coverage": [
             "phpdbg -qrr -d memory_limit=-1 ./vendor/bin/simple-phpunit --colors=always --testdox --coverage-html=tests/coverage"

--- a/composer.lock
+++ b/composer.lock
@@ -133,16 +133,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.44",
+            "version": "0.12.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "330b45776ea77f167b150e24787412414a8fa469"
+                "reference": "e96dd5e7ae9aefed663bc7e285ad96792b67eadc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/330b45776ea77f167b150e24787412414a8fa469",
-                "reference": "330b45776ea77f167b150e24787412414a8fa469",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e96dd5e7ae9aefed663bc7e285ad96792b67eadc",
+                "reference": "e96dd5e7ae9aefed663bc7e285ad96792b67eadc",
                 "shasum": ""
             },
             "require": {
@@ -185,20 +185,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-24T15:28:47+00:00"
+            "time": "2020-10-25T07:23:44+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.6",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -236,7 +236,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-08-10T04:50:15+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "stevegrunwell/runkit7-installer",
@@ -280,16 +280,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v5.1.5",
+            "version": "v5.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "e7d37c91486a0f9eed58a8c23822e1870ea36db5"
+                "reference": "150aeb91dd9dafe13ec8416abd62e435330ca12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/e7d37c91486a0f9eed58a8c23822e1870ea36db5",
-                "reference": "e7d37c91486a0f9eed58a8c23822e1870ea36db5",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/150aeb91dd9dafe13ec8416abd62e435330ca12d",
+                "reference": "150aeb91dd9dafe13ec8416abd62e435330ca12d",
                 "shasum": ""
             },
             "require": {
@@ -297,6 +297,9 @@
             },
             "conflict": {
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0|<6.4,>=6.0|9.1.2"
+            },
+            "require-dev": {
+                "symfony/deprecation-contracts": "^2.1"
             },
             "suggest": {
                 "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
@@ -355,7 +358,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-01T13:16:17+00:00"
+            "time": "2020-10-02T12:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,8 +3,5 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
-        # PHPUnit framework classes are provided by symfony/phpunit-bridge.
-        -
-            message: '#^Class PHPUnit\\Framework\\.+ not found\.$#'
-            path: *
+    scanDirectories:
+        - vendor/bin/.phpunit

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,5 +3,17 @@ parameters:
     paths:
         - src
         - tests
-    scanDirectories:
-        - vendor/bin/.phpunit
+
+    bootstrapFiles:
+        - vendor/bin/.phpunit/phpunit/vendor/autoload.php
+
+    ignoreErrors:
+        # Don't require return type hinting in tests.
+        -
+            message: '#Method \S+ has no return typehint specified\.#'
+            path: tests/*
+
+        # Strings are a valid callable type.
+        -
+            message: '#Parameter \#1 \$function of function call_user_func_array expects callable\(\): mixed, string given\.#'
+            path: src/Support/Runkit.php

--- a/src/Concerns/Runkit.php
+++ b/src/Concerns/Runkit.php
@@ -10,6 +10,11 @@ trait Runkit
      * Mark a test as skipped if Runkit is not available.
      *
      * @throws \PHPUnit\Framework\SkippedTestError
+     *
+     * @param string $message Optional. A message to include if the SkippedTestError exception
+     *                        is thrown. Default is empty.
+     *
+     * @return void
      */
     protected function requiresRunkit($message = '')
     {
@@ -22,9 +27,12 @@ trait Runkit
 
     /**
      * Determine whether or not Runkit is available in the current environment.
+     *
+     * @return bool
      */
     protected function isRunkitAvailable()
     {
-        return function_exists('runkit_constant_redefine');
+        return function_exists('runkit7_constant_redefine')
+            || function_exists('runkit_constant_redefine');
     }
 }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -3,6 +3,7 @@
 namespace AssertWell\PHPUnitGlobalState;
 
 use AssertWell\PHPUnitGlobalState\Exceptions\RedefineException;
+use AssertWell\PHPUnitGlobalState\Support\Runkit;
 
 trait Constants
 {
@@ -33,7 +34,7 @@ trait Constants
     {
         foreach ($this->_constants['updated'] as $name => $value) {
             if (defined($name)) {
-                runkit_constant_redefine($name, $value);
+                Runkit::constant_redefine($name, $value);
             } else {
                 define($name, $value);
             }
@@ -41,7 +42,7 @@ trait Constants
 
         foreach ($this->_constants['created'] as $name) {
             if (defined($name)) {
-                runkit_constant_remove($name);
+                Runkit::constant_remove($name);
             }
         }
     }
@@ -66,7 +67,7 @@ trait Constants
             }
 
             try {
-                runkit_constant_redefine($name, $value);
+                Runkit::constant_redefine($name, $value);
             } catch (\Exception $e) {
                 throw new RedefineException(sprintf(
                     'Unable to redefine constant "%s" with value "%s".',
@@ -99,7 +100,7 @@ trait Constants
             $this->_constants['updated'][$name] = constant($name);
         }
 
-        runkit_constant_remove($name);
+        Runkit::constant_remove($name);
 
         return $this;
     }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -18,6 +18,8 @@ trait Constants
 
     /**
      * @before
+     *
+     * @return void
      */
     protected function resetConstants()
     {
@@ -29,6 +31,8 @@ trait Constants
 
     /**
      * @after
+     *
+     * @return void
      */
     protected function restoreConstants()
     {
@@ -56,6 +60,8 @@ trait Constants
      *
      * @param string $name  The constant name.
      * @param mixed  $value The scalar value to store in the constant.
+     *
+     * @return self
      */
     protected function setConstant($name, $value = null)
     {
@@ -87,6 +93,8 @@ trait Constants
      * Delete a constant.
      *
      * @param string $name The constant name.
+     *
+     * @return self
      */
     protected function deleteConstant($name)
     {

--- a/src/EnvironmentVariables.php
+++ b/src/EnvironmentVariables.php
@@ -13,6 +13,8 @@ trait EnvironmentVariables
 
     /**
      * @before
+     *
+     * @return void
      */
     protected function resetEnvironmentVariableRegistry()
     {
@@ -21,6 +23,8 @@ trait EnvironmentVariables
 
     /**
      * @after
+     *
+     * @return void
      */
     protected function restoreEnvironmentVariables()
     {
@@ -37,6 +41,8 @@ trait EnvironmentVariables
      * @param string $variable The environment variable name.
      * @param mixed  $value    The value to store in the environment variable. Passing NULL will
      *                         delete the environment variable.
+     *
+     * @return self
      */
     protected function setEnvironmentVariable($variable, $value = null)
     {
@@ -53,6 +59,8 @@ trait EnvironmentVariables
      * Delete an environment variable.
      *
      * @param string $variable The variable name.
+     *
+     * @return self
      */
     protected function deleteEnvironmentVariable($variable)
     {

--- a/src/GlobalVariables.php
+++ b/src/GlobalVariables.php
@@ -11,6 +11,8 @@ trait GlobalVariables
 
     /**
      * @before
+     *
+     * @return void
      */
     protected function resetGlobalVariables()
     {
@@ -22,6 +24,8 @@ trait GlobalVariables
 
     /**
      * @after
+     *
+     * @return void
      */
     protected function restoreGlobalVariables()
     {
@@ -42,6 +46,8 @@ trait GlobalVariables
      * @param string $variable The global variable name.
      * @param mixed  $value    The new, temporary value. Passing NULL will unset the given
      *                         $variable, if it exists.
+     *
+     * @return void
      */
     protected function setGlobalVariable($variable, $value)
     {

--- a/src/Support/Runkit.php
+++ b/src/Support/Runkit.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * A utility class to ensure we're calling the runkit7_* functions when available, as the runkit_*
+ * versions are deprecated in newer versions of PHP.
+ */
+
+namespace AssertWell\PHPUnitGlobalState\Support;
+
+/**
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ * @method bool constant_add(string $constname, mixed $value[, int $newVisibility])
+ * @method bool constant_redefine(string $constname, mixed $value[, int $newVisibility])
+ * @method bool constant_remove(string $constname)
+ * @method bool function_add(string $funcname, string $arglist, string $code[, bool $return_by_reference = NULL[, string $doc_comment = NULL[, string $return_type[, bool $is_strict]]]])
+ * @method bool function_copy(string $funcname, string $targetname)
+ * @method bool function_redefine(string $funcname, string $arglist, string $code[, bool $return_by_reference = NULL[, string $doc_comment = NULL[, string $return_type[, bool $is_strict]]]])
+ * @method bool function_remove(string $funcname)
+ * @method bool function_rename(string $funcname, string $newname)
+ * @method bool import(string $filename[, int $flags])
+ * @method bool  method_add(string $classname, string $methodname, string $args, string $code[, int $flags = RUNKIT7_ACC_PUBLIC[, string $doc_comment = NULL[, string $return_type[, bool $is_strict]]]])
+ * @method bool  method_copy(string $dClass, string $dMethod, string $sClass[, string $sMethod])
+ * @method bool  method_redefine(string $classname, string $methodname, string $args, string $code[, int $flags = RUNKIT7_ACC_PUBLIC[, string $doc_comment = NULL[, string $return_type[, bool $is_strict]]]])
+ * @method bool  method_remove(string $classname, string $methodname)
+ * @method bool  method_rename(string $classname, string $methodname, string $newname)
+ * @method int   object_id(object $obj) : int
+ * @method array superglobals(void)
+ * @method array zval_inspect(string $value)
+ * phpcs:enable Generic.Files.LineLength.TooLong
+ */
+class Runkit
+{
+    /**
+     * Dynamically alias methods to the underlying Runkit functions.
+     *
+     * @throws \BadFunctionCallException if the underlying function does not exist.
+     *
+     * @param string $method The method name.
+     * @param array  $args   Method arguments.
+     *
+     * @return mixed The return value of the corresponding runkit(7)_* functions.
+     */
+    public static function __callStatic($name, array $args = [])
+    {
+        if (function_exists('runkit7_' . $name)) {
+            return call_user_func_array('runkit7_' . $name, $args);
+        }
+
+        if (function_exists('runkit_' . $name)) {
+            return call_user_func_array('runkit7_' . $name, $args);
+        }
+
+        throw new \BadFunctionCallException(sprintf(
+            'Runkit7 does not include a runkit7_%1$s() function.',
+            $name
+        ));
+    }
+}

--- a/src/Support/Runkit.php
+++ b/src/Support/Runkit.php
@@ -9,23 +9,23 @@ namespace AssertWell\PHPUnitGlobalState\Support;
 
 /**
  * phpcs:disable Generic.Files.LineLength.TooLong
- * @method bool constant_add(string $constname, mixed $value[, int $newVisibility])
- * @method bool constant_redefine(string $constname, mixed $value[, int $newVisibility])
- * @method bool constant_remove(string $constname)
- * @method bool function_add(string $funcname, string $arglist, string $code[, bool $return_by_reference = NULL[, string $doc_comment = NULL[, string $return_type[, bool $is_strict]]]])
- * @method bool function_copy(string $funcname, string $targetname)
- * @method bool function_redefine(string $funcname, string $arglist, string $code[, bool $return_by_reference = NULL[, string $doc_comment = NULL[, string $return_type[, bool $is_strict]]]])
- * @method bool function_remove(string $funcname)
- * @method bool function_rename(string $funcname, string $newname)
- * @method bool import(string $filename[, int $flags])
- * @method bool  method_add(string $classname, string $methodname, string $args, string $code[, int $flags = RUNKIT7_ACC_PUBLIC[, string $doc_comment = NULL[, string $return_type[, bool $is_strict]]]])
- * @method bool  method_copy(string $dClass, string $dMethod, string $sClass[, string $sMethod])
- * @method bool  method_redefine(string $classname, string $methodname, string $args, string $code[, int $flags = RUNKIT7_ACC_PUBLIC[, string $doc_comment = NULL[, string $return_type[, bool $is_strict]]]])
- * @method bool  method_remove(string $classname, string $methodname)
- * @method bool  method_rename(string $classname, string $methodname, string $newname)
- * @method int   object_id(object $obj) : int
- * @method array superglobals(void)
- * @method array zval_inspect(string $value)
+ * @method static bool constant_add(string $constname, mixed $value, int $newVisibility = NULL)
+ * @method static bool constant_redefine(string $constname, mixed $value, int $newVisibility = NULL)
+ * @method static bool constant_remove(string $constname)
+ * @method static bool function_add(string $funcname, string $arglist, string $code, bool $return_by_reference = NULL, string $doc_comment = NULL, string $return_type, bool $is_strict = NULL)
+ * @method static bool function_copy(string $funcname, string $targetname)
+ * @method static bool function_redefine(string $funcname, string $arglist, string $code, bool $return_by_reference = NULL, string $doc_comment = NULL, string $return_type = NULL, bool $is_strict)
+ * @method static bool function_remove(string $funcname)
+ * @method static bool function_rename(string $funcname, string $newname)
+ * @method static bool import(string $filename, int $flags = NULL)
+ * @method static bool  method_add(string $classname, string $methodname, string $args, string $code, int $flags = RUNKIT7_ACC_PUBLIC, string $doc_comment = NULL, string $return_type = NULL, bool $is_strict = NULL)
+ * @method static bool  method_copy(string $dClass, string $dMethod, string $sClass, string $sMethod = NULL)
+ * @method static bool  method_redefine(string $classname, string $methodname, string $args, string $code, int $flags = RUNKIT7_ACC_PUBLIC, string $doc_comment = NULL, string $return_type, bool $is_strict = NULL)
+ * @method static bool  method_remove(string $classname, string $methodname)
+ * @method static bool  method_rename(string $classname, string $methodname, string $newname)
+ * @method static int   object_id(object $obj)
+ * @method static array superglobals()
+ * @method static array zval_inspect(string $value)
  * phpcs:enable Generic.Files.LineLength.TooLong
  */
 class Runkit
@@ -35,8 +35,8 @@ class Runkit
      *
      * @throws \BadFunctionCallException if the underlying function does not exist.
      *
-     * @param string $method The method name.
-     * @param array  $args   Method arguments.
+     * @param string  $name The method name.
+     * @param mixed[] $args Method arguments.
      *
      * @return mixed The return value of the corresponding runkit(7)_* functions.
      */
@@ -47,7 +47,7 @@ class Runkit
         }
 
         if (function_exists('runkit_' . $name)) {
-            return call_user_func_array('runkit7_' . $name, $args);
+            return call_user_func_array('runkit_' . $name, $args);
         }
 
         throw new \BadFunctionCallException(sprintf(

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -31,7 +31,7 @@ class ConstantsTest extends TestCase
      */
     public function setConstant_should_be_able_to_handle_newly_defined_constants()
     {
-        $this->requiresRunkit('This test depends on runkit being unavailable.');
+        $this->requiresRunkit('This test depends on runkit being available.');
 
         $this->assertFalse(defined('SOME_CONSTANT'));
 
@@ -48,7 +48,7 @@ class ConstantsTest extends TestCase
      */
     public function setConstant_should_be_able_to_redefine_existing_constants()
     {
-        $this->requiresRunkit('This test depends on runkit being unavailable.');
+        $this->requiresRunkit('This test depends on runkit being available.');
 
         $this->setConstant('EXISTING_CONSTANT', 'some other value');
         $this->assertSame('some other value', constant('EXISTING_CONSTANT'));
@@ -67,7 +67,7 @@ class ConstantsTest extends TestCase
      */
     public function setConstant_should_throw_an_exception_if_it_cannot_redefine_a_constant()
     {
-        $this->requiresRunkit('This test depends on runkit being unavailable.');
+        $this->requiresRunkit('This test depends on runkit being available.');
 
         $this->expectException(RedefineException::class);
         $this->setConstant('EXISTING_CONSTANT', (object) ['some' => 'object']);
@@ -85,7 +85,7 @@ class ConstantsTest extends TestCase
      */
     public function deleteConstant_should_remove_an_existing_constant()
     {
-        $this->requiresRunkit('This test depends on runkit being unavailable.');
+        $this->requiresRunkit('This test depends on runkit being available.');
 
         $this->deleteConstant('DELETE_THIS_CONSTANT');
         $this->assertFalse(defined('DELETE_THIS_CONSTANT'));


### PR DESCRIPTION
Since the `runkit_*` functions have been deprecated in newer versions of PHP, introduce a `Runkit` helper class that will try to use the `runkit7_*` version (if they exist).

In order to get things passing, this also adds the missing typehints originally from another PR, so this also closes #13.