### PR TITLE
Simplify the setup of traits

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -14,20 +14,10 @@ trait Constants
      *
      * @var array[]
      */
-    private $_constants;
-
-    /**
-     * @before
-     *
-     * @return void
-     */
-    protected function resetConstants()
-    {
-        $this->_constants = [
-            'created' => [],
-            'updated' => [],
-        ];
-    }
+    private $constants = [
+        'created' => [],
+        'updated' => [],
+    ];
 
     /**
      * @after
@@ -36,7 +26,7 @@ trait Constants
      */
     protected function restoreConstants()
     {
-        foreach ($this->_constants['updated'] as $name => $value) {
+        foreach ($this->constants['updated'] as $name => $value) {
             if (defined($name)) {
                 Runkit::constant_redefine($name, $value);
             } else {
@@ -44,7 +34,7 @@ trait Constants
             }
         }
 
-        foreach ($this->_constants['created'] as $name) {
+        foreach ($this->constants['created'] as $name) {
             if (defined($name)) {
                 Runkit::constant_remove($name);
             }
@@ -68,8 +58,8 @@ trait Constants
         $this->requiresRunkit('setConstant() requires Runkit be available, skipping.');
 
         if (defined($name)) {
-            if (! isset($this->_constants['updated'][$name])) {
-                $this->_constants['updated'][$name] = constant($name);
+            if (! isset($this->constants['updated'][$name])) {
+                $this->constants['updated'][$name] = constant($name);
             }
 
             try {
@@ -82,7 +72,7 @@ trait Constants
                 ));
             }
         } else {
-            $this->_constants['created'][] = $name;
+            $this->constants['created'][] = $name;
             define($name, $value);
         }
 
@@ -104,8 +94,8 @@ trait Constants
 
         $this->requiresRunkit('deleteConstant() requires Runkit be available, skipping.');
 
-        if (! isset($this->_constants[$name])) {
-            $this->_constants['updated'][$name] = constant($name);
+        if (! isset($this->constants[$name])) {
+            $this->constants['updated'][$name] = constant($name);
         }
 
         Runkit::constant_remove($name);

--- a/src/EnvironmentVariables.php
+++ b/src/EnvironmentVariables.php
@@ -9,17 +9,7 @@ trait EnvironmentVariables
      *
      * @var mixed[]
      */
-    private $_environmentVariables;
-
-    /**
-     * @before
-     *
-     * @return void
-     */
-    protected function resetEnvironmentVariableRegistry()
-    {
-        $this->_environmentVariables = [];
-    }
+    private $environmentVariables = [];
 
     /**
      * @after
@@ -28,7 +18,7 @@ trait EnvironmentVariables
      */
     protected function restoreEnvironmentVariables()
     {
-        foreach ($this->_environmentVariables as $variable => $value) {
+        foreach ($this->environmentVariables as $variable => $value) {
             putenv(false === $value ? $variable : "${variable}=${value}");
         }
     }
@@ -46,8 +36,8 @@ trait EnvironmentVariables
      */
     protected function setEnvironmentVariable($variable, $value = null)
     {
-        if (! isset($this->_environmentVariables[$variable])) {
-            $this->_environmentVariables[$variable] = getenv($variable);
+        if (! isset($this->environmentVariables[$variable])) {
+            $this->environmentVariables[$variable] = getenv($variable);
         }
 
         putenv(null === $value ? $variable : "${variable}=${value}");

--- a/src/GlobalVariables.php
+++ b/src/GlobalVariables.php
@@ -7,20 +7,10 @@ trait GlobalVariables
     /**
      * @var array[]
      */
-    private $_globalVariables;
-
-    /**
-     * @before
-     *
-     * @return void
-     */
-    protected function resetGlobalVariables()
-    {
-        $this->_globalVariables = [
-            'created' => [],
-            'updated' => [],
-        ];
-    }
+    private $globalVariables = [
+        'created' => [],
+        'updated' => [],
+    ];
 
     /**
      * @after
@@ -30,12 +20,12 @@ trait GlobalVariables
     protected function restoreGlobalVariables()
     {
         // Restore existing values.
-        foreach ($this->_globalVariables['updated'] as $var => $value) {
+        foreach ($this->globalVariables['updated'] as $var => $value) {
             $GLOBALS[$var] = $value;
         }
 
         // Remove anything that was freshly-defined.
-        foreach ($this->_globalVariables['created'] as $var) {
+        foreach ($this->globalVariables['created'] as $var) {
             unset($GLOBALS[$var]);
         }
     }
@@ -52,9 +42,9 @@ trait GlobalVariables
     protected function setGlobalVariable($variable, $value)
     {
         if (! isset($GLOBALS[$variable])) {
-            $this->_globalVariables['created'][] = $variable;
-        } elseif (! isset($this->_globalVariables['updated'][$variable])) {
-            $this->_globalVariables['updated'][$variable] = $GLOBALS[$variable];
+            $this->globalVariables['created'][] = $variable;
+        } elseif (! isset($this->globalVariables['updated'][$variable])) {
+            $this->globalVariables['updated'][$variable] = $GLOBALS[$variable];
         }
 
         if (null === $value) {

--- a/tests/Concerns/RunkitTest.php
+++ b/tests/Concerns/RunkitTest.php
@@ -56,8 +56,14 @@ class RunkitTest extends TestCase
         $method = new \ReflectionMethod($this->instance, 'requiresRunkit');
         $method->setAccessible(true);
 
-        $this->expectException(SkippedTestError::class);
+        // Older versions of PHPUnit will actually try to mark this as skipped.
+        try {
+            $method->invoke($this->instance);
+        } catch (SkippedTestError $e) {
+            $this->assertInstanceOf(SkippedTestError::class, $e);
+            return;
+        }
 
-        $method->invoke($this->instance);
+        $this->fail('Did not catch the expected SkippedTestError.');
     }
 }

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests;
+
+use AssertWell\PHPUnitGlobalState\Exceptions\RedefineException;
+use PHPUnit\Framework\SkippedTestError;
+
+/**
+ * Tests to ensure that state may be set in PHPUnit fixtures.
+ *
+ * @ticket https://github.com/assertwell/phpunit-global-state/issues/14
+ */
+class FixtureTest extends TestCase
+{
+    protected $backupGlobalsBlacklist = [
+        'FIXTURE_BEFORE_GLOBAL',
+        'FIXTURE_SETUP_GLOBAL',
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setConstant('FIXTURE_SETUP_CONSTANT', true);
+        $this->setEnvironmentVariable('FIXTURE_SETUP_ENV', 'abc');
+        $this->setGlobalVariable('FIXTURE_SETUP_GLOBAL', true);
+    }
+
+    /**
+     * @before
+     */
+    protected function defineInitialValues()
+    {
+        $this->setConstant('FIXTURE_BEFORE_CONSTANT', true);
+        $this->setEnvironmentVariable('FIXTURE_BEFORE_ENV', 'xyz');
+        $this->setGlobalVariable('FIXTURE_BEFORE_GLOBAL', true);
+    }
+
+    /**
+     * @test
+     * @group Constants
+     */
+    public function it_should_permit_constants_to_be_set_in_fixtures_method()
+    {
+        $this->assertTrue(
+            defined('FIXTURE_SETUP_CONSTANT'),
+            'The constant should have been defined in the setUp() method.'
+        );
+        $this->assertTrue(
+            defined('FIXTURE_BEFORE_CONSTANT'),
+            'The constant should have been defined in the @before method.'
+        );
+
+        $this->restoreConstants();
+        $this->assertFalse(
+            defined('FIXTURE_SETUP_CONSTANT'),
+            'The constant should have been undefined by restoreConstants().'
+        );
+        $this->assertFalse(
+            defined('FIXTURE_BEFORE_CONSTANT'),
+            'The constant should have been undefined by restoreConstants().'
+        );
+    }
+
+    /**
+     * @test
+     * @group EnvironmentVariables
+     */
+    public function it_should_permit_environment_variables_to_be_set_in_fixtures_method()
+    {
+        $this->assertSame(
+            'abc',
+            getenv('FIXTURE_SETUP_ENV'),
+            'The environment variable should have been defined in the setUp() method.'
+        );
+        $this->assertSame(
+            'xyz',
+            getenv('FIXTURE_BEFORE_ENV'),
+            'The environment variable should have been defined in the @before method.'
+        );
+
+        $this->restoreEnvironmentVariables();
+        $this->assertFalse(
+            getenv('FIXTURE_SETUP_ENV'),
+            'The environment variable should have been undefined by restoreGlobalVariables().'
+        );
+        $this->assertFalse(
+            getenv('FIXTURE_BEFORE_ENV'),
+            'The environment variable should have been undefined by restoreGlobalVariables().'
+        );
+    }
+
+    /**
+     * @test
+     * @group GlobalVariables
+     */
+    public function it_should_permit_global_variables_to_be_set_in_fixtures_method()
+    {
+        $this->assertTrue(
+            isset($GLOBALS['FIXTURE_SETUP_GLOBAL']),
+            'The global variable should have been defined in the setUp() method.'
+        );
+        $this->assertTrue(
+            isset($GLOBALS['FIXTURE_BEFORE_GLOBAL']),
+            'The global variable should have been defined in the @before method.'
+        );
+
+        $this->restoreGlobalVariables();
+        $this->assertFalse(
+            isset($GLOBALS['FIXTURE_SETUP_GLOBAL']),
+            'The global variable should have been undefined by restoreGlobalVariables().'
+        );
+        $this->assertFalse(
+            isset($GLOBALS['FIXTURE_BEFORE_GLOBAL']),
+            'The global variable should have been undefined by restoreGlobalVariables().'
+        );
+    }
+}

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use AssertWell\PHPUnitGlobalState\Exceptions\RedefineException;
 use PHPUnit\Framework\SkippedTestError;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Tests to ensure that state may be set in PHPUnit fixtures.
@@ -12,12 +13,14 @@ use PHPUnit\Framework\SkippedTestError;
  */
 class FixtureTest extends TestCase
 {
+    use SetUpTearDownTrait;
+
     protected $backupGlobalsBlacklist = [
         'FIXTURE_BEFORE_GLOBAL',
         'FIXTURE_SETUP_GLOBAL',
     ];
 
-    public function setUp(): void
+    public function doSetUp()
     {
         parent::setUp();
 

--- a/tests/GlobalVariablesTest.php
+++ b/tests/GlobalVariablesTest.php
@@ -9,6 +9,10 @@ namespace Tests;
  */
 class GlobalVariablesTest extends TestCase
 {
+    protected $backupGlobalsBlacklist = [
+        'setGlobalVariable',
+    ];
+
     /**
      * @test
      * @testdox setGlobalVariable() should be able to handle new global variables


### PR DESCRIPTION
Instead of using `@before` fixture methods to reset the [private] properties that keep track of what's changed in each trait, set the property values directly.

Fixes #14.