### PR TITLE
WIP: Define a Methods trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The library offers a number of traits, based on the type of global state that mi
 * [Environment Variables](docs/EnvironmentVariables.md)
 * [Functions](docs/Functions.md) (requires [Runkit7])
 * [Global Variables](docs/GlobalVariables.md)
+* [Methods](docs/Methods.md) (requires[Runkit7])
 
 
 ## Contributing

--- a/docs/Methods.md
+++ b/docs/Methods.md
@@ -1,0 +1,100 @@
+# Managing Methods
+
+When writing tests, we often make use of [test doubles](https://en.wikipedia.org/wiki/Test_double) to better control how our code will behave. For instance, we don't want to make calls to remote APIs every time we run our tests, as these dependencies can make our tests fragile and slow.
+
+If your software is written using proper [Dependency Injection](https://phptherightway.com/#dependency_injection), it's usually pretty easy to [create test doubles with PHPUnit](https://jmauerhan.wordpress.com/2018/10/04/the-5-types-of-test-doubles-and-how-to-create-them-in-phpunit/) and inject them into the objects we create in our tests.
+
+What happens when the software we're working with isn't coded so nicely, though?
+
+Most of the time, we can get around this using [Reflection](https://www.php.net/intro.reflection), but _sometimes_ we need a sledgehammer to break through. That's where the `AssertWell\PHPUnitGlobalState\Methods` trait (powered by [PHP's runkit7 extension](Runkit.md)) comes in handy.
+
+
+## Methods
+
+As all of these methods require [runkit7](Runkit.md), tests that use these methods will automatically be marked as skipped if the extension is unavailable.
+
+---
+
+### defineMethod()
+
+Define a new method for the duration of the test.
+
+`defineMethod(string $class, string $name, \Closure $closure, string $visibility = 'public', bool $static = false): self`
+
+This is a wrapper around [PHP's `runkit7_method_define()` function](https://www.php.net/manual/en/function.runkit7-method-define.php).
+
+#### Parameters
+
+<dl>
+    <dt>$class</dt>
+    <dd>The class name.</dd>
+    <dt>$name</dt>
+    <dd>The method name.</dd>
+    <dt>$closure</dt>
+    <dd>The code for the method.</dd>
+    <dt>$visibility</dt>
+    <dd>Optional. The method visibility, one of "public", "protected", or "private".</dd>
+    <dt>$static</dt>
+    <dd>Optional. Whether or not the method should be static. Default is false.</dd>
+</dl>
+
+#### Return values
+
+This method will return the calling class, enabling multiple methods to be chained.
+
+An `AssertWell\PHPUnitGlobalState\Exceptions\MethodExistsException` exception will be thrown if the given `$method` already exists. An `AssertWell\PHPUnitGlobalState\Exceptions\RunkitException` will be thrown if the given method cannot be defined.
+
+---
+
+### redefineMethod()
+
+Redefine an existing method for the duration of the test. If `$name` does not exist, it will be defined.
+
+`redefineMethod(string $class, string $name, ?\Closure $closure, ?string $visibility = null, ?bool $static = null): self`
+
+This is a wrapper around [PHP's `runkit7_method_redefine()` function](https://www.php.net/manual/en/function.runkit7-method-redefine.php).
+
+#### Parameters
+
+<dl>
+    <dt>$class</dt>
+    <dd>The class name.</dd>
+    <dt>$name</dt>
+    <dd>The method name.</dd>
+    <dt>$closure</dt>
+    <dd>The new code for the method.</dd>
+    <dd>If <code>null</code> is passed, the existing method body will be copied.</dd>
+    <dt>$visibility</dt>
+    <dd>Optional. The method visibility, one of "public", "protected", or "private".</dd>
+    <dd>If <code>null</code> is passed, the existing visibility will be preserved.</dd>
+    <dt>$static</dt>
+    <dd>Optional. Whether or not the method should be static. Default is false.</dd>
+    <dd>If <code>null</code> is passed, the existing state will be used.</dd>
+</dl>
+
+#### Return values
+
+This method will return the calling class, enabling multiple methods to be chained.
+
+An `AssertWell\PHPUnitGlobalState\Exceptions\RunkitException` will be thrown if the given method cannot be (re)defined.
+
+---
+
+### deleteMethod()
+
+Delete/undefine a method for the duration of the single test.
+
+`deleteMethod(string $class, string $name): self`
+
+#### Parameters
+
+<dl>
+    <dt>$class</dt>
+    <dd>The class name.</dd>
+    <dt>$name</dt>
+    <dd>The method name.</dd>
+</dl>
+
+#### Return values
+
+This method will return the calling class, enabling multiple methods to be chained.

--- a/src/Exceptions/MethodExistsException.php
+++ b/src/Exceptions/MethodExistsException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AssertWell\PHPUnitGlobalState\Exceptions;
+
+class MethodExistsException extends FunctionExistsException
+{
+
+}

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace AssertWell\PHPUnitGlobalState;
+
+use AssertWell\PHPUnitGlobalState\Exceptions\MethodExistsException;
+use AssertWell\PHPUnitGlobalState\Exceptions\RunkitException;
+use AssertWell\PHPUnitGlobalState\Support\Runkit;
+
+trait Methods
+{
+    /**
+     * All methods being handled by this trait.
+     *
+     * @var array[]
+     */
+    private $methods = [
+        'defined'   => [],
+        'redefined' => [],
+    ];
+
+    /**
+     * @after
+     *
+     * @return void
+     */
+    protected function restoreMethods()
+    {
+        // Reset anything that was modified.
+        array_walk($this->methods['redefined'], function ($methods, $class) {
+            foreach ($methods as $modified => $original) {
+                if (method_exists($class, $modified)) {
+                    Runkit::method_remove($class, $modified);
+                }
+
+                // Put the original back into place.
+                Runkit::method_rename($class, $original, $modified);
+            }
+
+            unset($this->methods['redefined'][$class]);
+        });
+
+        array_walk($this->methods['defined'], function ($methods, $class) {
+            foreach ($methods as $method) {
+                Runkit::method_remove($class, $method);
+            }
+            unset($this->methods['defined'][$class]);
+        });
+
+        Runkit::reset();
+    }
+
+    /**
+     * Define a new method.
+     *
+     * @throws \AssertWell\PHPUnitGlobalState\Exceptions\MethodExistsException
+     * @throws \AssertWell\PHPUnitGlobalState\Exceptions\RunkitException
+     *
+     * @param string   $class      The class name.
+     * @param string   $name       The method name.
+     * @param \Closure $closure    The method body.
+     * @param string   $visibility Optional. The method visibility, one of "public", "protected",
+     *                             or "private". Default is "public".
+     * @param bool     $static     Optional. Whether or not the method should be defined as static.
+     *                             Default is false.
+     *
+     * @return self
+     */
+    protected function defineMethod($class, $name, \Closure $closure, $visibility = 'public', $static = false)
+    {
+        if (method_exists($class, $name)) {
+            throw new MethodExistsException(sprintf(
+                'Method %1$s::%2$s() already exists. You may redefine it using %3$s::redefineMethod() instead.',
+                $class,
+                $name,
+                get_class($this)
+            ));
+        }
+
+        if (! Runkit::isAvailable()) {
+            $this->markTestSkipped('defineMethod() requires Runkit be available, skipping.');
+        }
+
+        $flags = Runkit::getVisibilityFlags($visibility, $static);
+
+        if (! Runkit::method_add($class, $name, $closure, $flags)) {
+            throw new RunkitException(sprintf('Unable to define method %1$s::%2$s().', $class, $name));
+        }
+
+        if (! isset($this->methods['defined'][$class])) {
+            $this->methods['defined'][$class] = [];
+        }
+        $this->methods['defined'][$class][] = $name;
+
+        return $this;
+    }
+
+    /**
+     * Redefine an existing method.
+     *
+     * If the method doesn't yet exist, it will be defined.
+     *
+     * @param string        $class      The class name.
+     * @param string        $name       The method name.
+     * @param \Closure|null $closure    Optional. A closure representing the method body. If null,
+     *                                  the method body will not be replaced. Default is null.
+     * @param string        $visibility Optional. The method visibility, one of "public",
+     *                                  "protected", or "private". Default is the same as the
+     *                                  current value.
+     * @param bool          $static     Optional. Whether or not the method should be defined as
+     *                                  static. Default is the same is as the current value.
+     *
+     * @return self
+     */
+    protected function redefineMethod($class, $name, $closure = null, $visibility = null, $static = null)
+    {
+        if (! method_exists($class, $name)) {
+            if (! $closure instanceof \Closure) {
+                throw new RunkitException(
+                    sprintf('New method %1$s::$2$s() cannot have an empty body.', $class, $name)
+                );
+            }
+
+            return $this->defineMethod($class, $name, $closure, $visibility, $static);
+        }
+
+        if (! Runkit::isAvailable()) {
+            $this->markTestSkipped('redefineMethod() requires Runkit be available, skipping.');
+        }
+
+        $method = new \ReflectionMethod($class, $name);
+
+        if (null === $visibility) {
+            if ($method->isPrivate()) {
+                $visibility = 'private';
+            } elseif ($method->isProtected()) {
+                $visibility = 'protected';
+            } else {
+                $visibility = 'public';
+            }
+        }
+
+        if (null === $static) {
+            $static = $method->isStatic();
+        }
+
+        $flags = Runkit::getVisibilityFlags($visibility, $static);
+
+        // If $closure is null, copy the existing method body.
+        if (null === $closure) {
+            $closure = $method->isStatic()
+                ? $method->getClosure()
+                : $method->getClosure($this->getMockBuilder($class)
+                    ->disableOriginalConstructor()
+                    ->getMock());
+        }
+
+        // Back up the original version of the method.
+        if (! isset($this->methods['redefined'][$class][$name])) {
+            $prefixed = Runkit::makePrefixed($name);
+
+            if (! Runkit::method_rename($class, $name, $prefixed)) {
+                throw new RunkitException(
+                    sprintf('Unable to back up %1$s::%2$s(), aborting.', $class, $name)
+                );
+            }
+
+            if (! isset($this->methods['redefined'][$class])) {
+                $this->methods['redefined'][$class] = [];
+            }
+            $this->methods['redefined'][$class][$name] = $prefixed;
+
+            if (! Runkit::method_add($class, $name, $closure, $flags)) {
+                throw new RunkitException(
+                    sprintf('Unable to redefine function %1$s::%2$s().', $method, $name)
+                );
+            }
+        } else {
+            Runkit::method_redefine($class, $name, $closure, $flags);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Delete an existing method.
+     *
+     * @param string $class The class name.
+     * @param string $name  The method to be deleted.
+     *
+     * @return self
+     */
+    protected function deleteMethod($class, $name)
+    {
+        if (! method_exists($class, $name)) {
+            return $this;
+        }
+
+        $prefixed = Runkit::makePrefixed($name);
+
+        if (! Runkit::method_rename($class, $name, $prefixed)) {
+            throw new RunkitException(
+                sprintf('Unable to back up %1$s::%2$s(), aborting.', $class, $name)
+            );
+        }
+
+        if (! isset($this->methods['redefined'][$class])) {
+            $this->methods['redefined'][$class] = [];
+        }
+        $this->methods['redefined'][$class][$name] = $prefixed;
+
+        return $this;
+    }
+}

--- a/tests/MethodsTest.php
+++ b/tests/MethodsTest.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace Tests;
+
+use AssertWell\PHPUnitGlobalState\Exceptions\MethodExistsException;
+use AssertWell\PHPUnitGlobalState\Support\Runkit;
+use Tests\Stubs\TestClass;
+
+/**
+ * @covers AssertWell\PHPUnitGlobalState\Methods
+ *
+ * @group Methods
+ */
+class MethodsTest extends TestCase
+{
+    /**
+     * @before
+     */
+    protected function verifyRunkitIsAvailable()
+    {
+        if (! Runkit::isAvailable()) {
+            $this->markTestSkipped('This test depends on runkit being available.');
+        }
+    }
+
+    /**
+     * @test
+     * @testdox defineMethod() should be able to define a new method
+     */
+    public function defineMethod_should_be_able_to_define_a_new_method()
+    {
+        $this->assertFalse(method_exists(TestClass::class, 'myMethod'));
+
+        $this->defineMethod(TestClass::class, 'myMethod', function ($return) {
+            return $return;
+        });
+
+        $this->assertSame(123, (new TestClass())->myMethod(123));
+
+        $this->restoreMethods();
+        $this->assertFalse(
+            method_exists(TestClass::class, 'myMethod'),
+            'The new method should have been undefined.'
+        );
+    }
+
+    /**
+     * @test
+     * @testdox defineMethod() should be able to set the visibility and static properties
+     * @dataProvider provideVisibilityStaticCombinations
+     * @depends defineMethod_should_be_able_to_define_a_new_method
+     *
+     * @param string $visibility The visibility to apply.
+     * @param bool   $static     Whether or not to make the method static.
+     */
+    public function defineMethod_should_be_able_to_set_visibility_and_static($visibility, $static)
+    {
+        $this->defineMethod(TestClass::class, 'myMethod', function ($return) {
+            return $return;
+        }, $visibility, $static);
+
+        $method           = new \ReflectionMethod(TestClass::class, 'myMethod');
+        $visibilityMethod = sprintf('is%s', ucwords($visibility));
+
+        $this->assertTrue(
+            $method->$visibilityMethod(),
+            sprintf('Expected method to be %s.', $visibility)
+        );
+        $this->assertSame(
+            $static,
+            $method->isStatic(),
+            $static ? 'Expected method to be static' : 'Expected method to not be static'
+        );
+    }
+
+    /**
+     * @test
+     * @testdox defineMethod() should throw a warning if the method already exists
+     */
+    public function defineMethod_should_throw_a_warning_if_the_method_already_exists()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'publicMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'publicMethod'));
+
+        $this->expectException(MethodExistsException::class);
+        $this->defineMethod(TestClass::class, 'publicMethod', function ($return) {
+            return $return;
+        });
+
+        $this->assertSame(
+            $signature,
+            (string) (new \ReflectionMethod(TestClass::class, 'publicMethod')),
+            'The original method should have been left untouched.'
+        );
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should be able to redefine an existing method
+     */
+    public function redefineMethod_should_be_able_to_redefine_existing_methods()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'publicMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'publicMethod'));
+
+        $this->redefineMethod(TestClass::class, 'publicMethod', function () {
+            return 123;
+        });
+
+        $this->assertSame(123, (new TestClass())->publicMethod('some string'));
+
+        $this->restoreMethods();
+        $this->assertTrue(method_exists(TestClass::class, 'publicMethod'));
+        $this->assertSame(
+            $signature,
+            (string) (new \ReflectionMethod(TestClass::class, 'publicMethod')),
+            'The original method definition should have been restored.'
+        );
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should be able to change method visibility
+     * @depends redefineMethod_should_be_able_to_redefine_existing_methods
+     */
+    public function redefineMethod_should_be_able_to_change_method_visibility()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'publicMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'publicMethod'));
+
+        $this->redefineMethod(TestClass::class, 'publicMethod', function () {
+            return 123;
+        }, 'protected');
+
+        $method = new \ReflectionMethod(TestClass::class, 'publicMethod');
+        $method->setAccessible(true);
+
+        $this->assertSame(123, $method->invoke(new TestClass()));
+        $this->assertTrue($method->isProtected());
+
+        $this->restoreMethods();
+        $this->assertSame(
+            $signature,
+            (string) (new \ReflectionMethod(TestClass::class, 'publicMethod')),
+            'The original method definition should have been restored.'
+        );
+        $this->assertTrue((new \ReflectionMethod(TestClass::class, 'publicMethod'))->isPublic());
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should be preserve visibility by default
+     * @depends redefineMethod_should_be_able_to_redefine_existing_methods
+     */
+    public function redefineMethod_should_preserve_visibility()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'protectedMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'protectedMethod'));
+
+        $this->redefineMethod(TestClass::class, 'protectedMethod', function () {
+            return 123;
+        });
+
+        $method = new \ReflectionMethod(TestClass::class, 'protectedMethod');
+        $this->assertTrue($method->isProtected());
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should be able to make a method static
+     * @depends redefineMethod_should_be_able_to_redefine_existing_methods
+     */
+    public function redefineMethod_should_be_able_to_make_a_method_static()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'publicMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'publicMethod'));
+
+        $this->redefineMethod(TestClass::class, 'publicMethod', function () {
+            return 123;
+        }, 'public', true);
+
+        $this->assertTrue((new \ReflectionMethod(TestClass::class, 'publicMethod'))->isStatic());
+        $this->assertSame(123, TestClass::publicMethod());
+
+        $this->restoreMethods();
+        $this->assertSame(
+            $signature,
+            (string) (new \ReflectionMethod(TestClass::class, 'publicMethod')),
+            'The original method definition should have been restored.'
+        );
+        $this->assertFalse((new \ReflectionMethod(TestClass::class, 'publicMethod'))->isStatic());
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should be preserve static state by default
+     * @depends redefineMethod_should_be_able_to_redefine_existing_methods
+     */
+    public function redefineMethod_should_preserve_static()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'protectedStaticMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'protectedStaticMethod'));
+
+        $this->redefineMethod(TestClass::class, 'protectedStaticMethod', function () {
+            return 123;
+        });
+
+        $method = new \ReflectionMethod(TestClass::class, 'protectedStaticMethod');
+        $this->assertTrue($method->isStatic());
+    }
+
+    /**
+     * @test
+     * @testdox Passing a null body to redefineMethod() should leave the original signature
+     * @depends redefineMethod_should_be_able_to_redefine_existing_methods
+     */
+    public function redefineMethod_can_accept_a_null_body()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'publicMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'publicMethod'));
+
+        $this->redefineMethod(TestClass::class, 'publicMethod', null, 'protected', true);
+
+        $method = new \ReflectionMethod(TestClass::class, 'publicMethod');
+        $this->assertTrue($method->isProtected(), 'The visibility changes should have been applied.');
+        $this->assertTrue($method->isStatic(), 'The static changes should have been applied.');
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should be able to make a method non-static
+     * @depends redefineMethod_should_be_able_to_redefine_existing_methods
+     */
+    public function redefineMethod_should_be_able_to_make_a_method_nonstatic()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'publicStaticMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'publicStaticMethod'));
+
+        $this->redefineMethod(TestClass::class, 'publicStaticMethod', function () {
+            return 123;
+        }, 'public', false);
+
+        $this->assertFalse((new \ReflectionMethod(TestClass::class, 'publicStaticMethod'))->isStatic());
+        $this->assertSame(123, (new TestClass())->publicStaticMethod());
+
+        $this->restoreMethods();
+        $this->assertSame(
+            $signature,
+            (string) (new \ReflectionMethod(TestClass::class, 'publicStaticMethod')),
+            'The original method definition should have been restored.'
+        );
+        $this->assertTrue((new \ReflectionMethod(TestClass::class, 'publicStaticMethod'))->isStatic());
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should be able to redefine newly-defined methods
+     */
+    public function redefineMethod_should_be_able_to_redefine_newly_defined_methods()
+    {
+        $this->defineMethod(TestClass::class, 'myMethod', function () {
+            return 'abc';
+        });
+        $this->redefineMethod(TestClass::class, 'myMethod', function () {
+            return 'xyz';
+        });
+
+        $this->assertSame('xyz', (new TestClass())->myMethod());
+
+        $this->restoreMethods();
+        $this->assertFalse(
+            method_exists(TestClass::class, 'myMethod'),
+            'The newly-created method should still be removed.'
+        );
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should be able to redefine an existing methods multiple times
+     * @depends redefineMethod_should_be_able_to_redefine_existing_methods
+     */
+    public function redefineMethod_should_be_able_to_redefine_existing_methods_multiple_times()
+    {
+        $this->assertTrue(method_exists(TestClass::class, 'publicMethod'));
+        $signature = (string) (new \ReflectionMethod(TestClass::class, 'publicMethod'));
+
+        $this->redefineMethod(TestClass::class, 'publicMethod', function () {
+            return 'first';
+        });
+        $this->redefineMethod(TestClass::class, 'publicMethod', function () {
+            return 'second';
+        });
+        $this->redefineMethod(TestClass::class, 'publicMethod', function () {
+            return 'third';
+        });
+
+        $this->assertSame(
+            'third',
+            (new TestClass())->publicMethod(),
+            'Expected the latest re-definition to be used.'
+        );
+
+        $this->restoreMethods();
+        $this->assertSame(
+            $signature,
+            (string) (new \ReflectionMethod(TestClass::class, 'publicMethod')),
+            'The original method definition should have been restored.'
+        );
+    }
+
+    /**
+     * @test
+     * @testdox redefineMethod() should define methods if they do not exist
+     * @depends redefineMethod_should_be_able_to_redefine_existing_methods
+     */
+    public function redefineMethod_should_define_methods_if_they_do_not_exist()
+    {
+        $this->assertFalse(method_exists(TestClass::class, 'myMethod'));
+
+
+        $this->redefineMethod(TestClass::class, 'myMethod', function () {
+            return 'value';
+        });
+
+        $this->assertSame('value', (new TestClass())->myMethod());
+
+        $this->restoreMethods();
+        $this->assertFalse(
+            method_exists(TestClass::class, 'myMethod'),
+            'The new method should have been undefined.'
+        );
+    }
+
+    /**
+     * @test
+     * @testdox deleteMethod() should be able to delete methods
+     */
+    public function deleteMethod_should_be_able_to_delete_methods()
+    {
+        $this->assertTrue(
+            method_exists(TestClass::class, 'publicMethod'),
+            'Test is predicated on this method existing.'
+        );
+
+        $this->deleteMethod(TestClass::class, 'publicMethod');
+        $this->assertFalse(
+            method_exists(TestClass::class, 'publicMethod'),
+            'The method should have been deleted.'
+        );
+
+        $this->restoreMethods();
+        $this->assertTrue(
+            method_exists(TestClass::class, 'publicMethod'),
+            'The method should have been restored.'
+        );
+    }
+
+    /**
+     * @test
+     * @testdox deleteMethod() should do nothing if the method does not exist
+     */
+    public function deleteMethod_should_do_nothing_if_the_method_does_not_exist()
+    {
+        $this->assertFalse(
+            method_exists(TestClass::class, 'someFakeMethod'),
+            'Test is predicated on this method NOT existing.'
+        );
+
+        $this->deleteMethod(TestClass::class, 'someFakeMethod');
+
+        $this->assertFalse(
+            method_exists(TestClass::class, 'someFakeMethod'),
+            'Deleting a non-existent method should not do anything.'
+        );
+
+        $this->restoreMethods();
+        $this->assertFalse(
+            method_exists(TestClass::class, 'someFakeMethod'),
+            'Nothing should be restored as there was nothing to begin with.'
+        );
+    }
+
+    /**
+     * Provide combinations of visibility and static.
+     *
+     * @return array[]
+     */
+    public function provideVisibilityStaticCombinations()
+    {
+        return [
+            'Public, non-static'    => ['public', false],
+            'Protected, non-static' => ['protected', false],
+            'Private, non-static'   => ['private', false],
+            'Public, static'        => ['public', true],
+            'Protected, static'     => ['protected', true],
+            'Private, static'       => ['private', true],
+        ];
+    }
+}

--- a/tests/Support/RunkitTest.php
+++ b/tests/Support/RunkitTest.php
@@ -56,4 +56,22 @@ class RunkitTest extends TestCase
             'Leading slashes should be stripped.'
         );
     }
+
+    /**
+     * @test
+     */
+    public function makePrefixed_should_return_the_given_reference_with_a_prefix()
+    {
+        $prefix = Runkit::getPrefix();
+
+        $this->assertSame(
+            $prefix . 'some_method',
+            Runkit::makePrefixed('some_method')
+        );
+        $this->assertSame(
+            $prefix . 'Some_Namespaced_function_to_move',
+            Runkit::makePrefixed('Some\\Namespaced\\function_to_move'),
+            'Namespaces should be preserved.'
+        );
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use AssertWell\PHPUnitGlobalState\Constants;
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use AssertWell\PHPUnitGlobalState\Functions;
 use AssertWell\PHPUnitGlobalState\GlobalVariables;
+use AssertWell\PHPUnitGlobalState\Methods;
 
 /**
  * Since this test suite is testing a series of traits meant to aid in testing other codebases
@@ -21,4 +22,5 @@ abstract class TestCase extends BaseTestCase
     use EnvironmentVariables;
     use Functions;
     use GlobalVariables;
+    use Methods;
 }

--- a/tests/stubs/TestClass.php
+++ b/tests/stubs/TestClass.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Stubs;
+
+class TestClass
+{
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    public function publicMethod($string = 'default')
+    {
+        return 'Public: ' . $string;
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    protected function protectedMethod($string = 'default')
+    {
+        return 'Protected: ' . $string;
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    private function privateMethod($string = 'default')
+    {
+        return 'Private: ' . $string;
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function publicStaticMethod($string = 'default')
+    {
+        return 'Public, static: ' . $string;
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    protected static function protectedStaticMethod($string = 'default')
+    {
+        return 'Protected, static: ' . $string;
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    private static function privateStaticMethod($string = 'default')
+    {
+        return 'Private, static: ' . $string;
+    }
+}


### PR DESCRIPTION
This trait exposes three methods:

1. `defineMethod(string $class, string $name, \Closure $closure, string $visibility = 'public', bool $static = false): self`
2. `redefineMethod(string $class, string $name, ?\Closure $closure, ?string $visibility = null, ?bool $static = null): self`
3. `deleteMethod(string $class, string $name): self`

Fixes #12.

## To-do:

- [ ] Document where this trait should actually be used and make it _very_ clear that it should be a last resort.