### PR TITLE
Removing unused namespaces

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,7 @@ parameters:
 
         # Strings are a valid callable type.
         -
-            message: '#Parameter \#1 \$function of function call_user_func_array expects callable\(\): mixed, string given\.#'
+            message: '#Parameter \#1 \S+ of function call_user_func_array expects callable\(\): mixed, string given\.#'
             path: src/Support/Runkit.php
 
         # Dynamically-defined functions.

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -4,7 +4,6 @@ namespace Tests;
 
 use AssertWell\PHPUnitGlobalState\Exceptions\RedefineException;
 use AssertWell\PHPUnitGlobalState\Support\Runkit;
-use PHPUnit\Framework\SkippedTestError;
 
 /**
  * @covers AssertWell\PHPUnitGlobalState\Constants

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests;
 
-use AssertWell\PHPUnitGlobalState\Exceptions\RedefineException;
-use PHPUnit\Framework\SkippedTestError;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
@@ -15,6 +13,9 @@ class FixtureTest extends TestCase
 {
     use SetUpTearDownTrait;
 
+    /**
+     * @var array<string>
+     */
     protected $backupGlobalsBlacklist = [
         'FIXTURE_BEFORE_GLOBAL',
         'FIXTURE_SETUP_GLOBAL',

--- a/tests/GlobalVariablesTest.php
+++ b/tests/GlobalVariablesTest.php
@@ -9,6 +9,9 @@ namespace Tests;
  */
 class GlobalVariablesTest extends TestCase
 {
+    /**
+     * @var array<string>
+     */
     protected $backupGlobalsBlacklist = [
         'setGlobalVariable',
     ];


### PR DESCRIPTION
# Changed log

- Removing some namespaces because they're unused.
- Using the message pattern to ignore the `call_user_func_array` parameter message.
- Adding the `@var array<string>` for document annotation to fix the static code analysis.