### PR TITLE
Version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Version 0.2.1] — 2021-04-15
+
+* Mark tests that use `defineFunction()` or `deleteFunction()` as skipped if Runkit is unavailable ([#25])
+
+
 ## [Version 0.2.0] — 2020-11-23
 
 * Introduce a [new `AssertWell\PHPUnitGlobalState\Functions` trait](docs/Functions.md) ([#17])
@@ -22,7 +27,9 @@ Initial public release of the package, with the following traits:
 
 [Unreleased]: https://github.com/assertwell/phpunit-global-state/compare/master...develop
 [Version 0.1.0]: https://github.com/assertwell/phpunit-global-state/tag/v0.1.0
-[Version 0.2.0]: https://github.com/assertwell/phpunit-global-state/tag/v0.1.0
+[Version 0.2.0]: https://github.com/assertwell/phpunit-global-state/tag/v0.2.0
+[Version 0.2.1]: https://github.com/assertwell/phpunit-global-state/tag/v0.2.1
 [#15]: https://github.com/assertwell/phpunit-global-state/pull/15
 [#16]: https://github.com/assertwell/phpunit-global-state/pull/16
 [#17]: https://github.com/assertwell/phpunit-global-state/pull/17
+[#25]: https://github.com/assertwell/phpunit-global-state/pull/25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Version 0.2.1] — 2021-04-15
 
 * Mark tests that use `defineFunction()` or `deleteFunction()` as skipped if Runkit is unavailable ([#25])
+* Fix coding standards, remove unused namespace imports ([#22], props [@peter279k](https://github.com/peter279k))
 
 
 ## [Version 0.2.0] — 2020-11-23
@@ -32,4 +33,5 @@ Initial public release of the package, with the following traits:
 [#15]: https://github.com/assertwell/phpunit-global-state/pull/15
 [#16]: https://github.com/assertwell/phpunit-global-state/pull/16
 [#17]: https://github.com/assertwell/phpunit-global-state/pull/17
+[#22]: https://github.com/assertwell/phpunit-global-state/pull/22
 [#25]: https://github.com/assertwell/phpunit-global-state/pull/25

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,7 @@ parameters:
 
         # Strings are a valid callable type.
         -
-            message: '#Parameter \#1 \$function of function call_user_func_array expects callable\(\): mixed, string given\.#'
+            message: '#Parameter \#1 \S+ of function call_user_func_array expects callable\(\): mixed, string given\.#'
             path: src/Support/Runkit.php
 
         # Dynamically-defined functions.

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -56,6 +56,10 @@ trait Functions
      */
     protected function defineFunction($name, \Closure $closure)
     {
+        if (! Runkit::isAvailable()) {
+            $this->markTestSkipped('defineFunction() requires Runkit be available, skipping.');
+        }
+
         if (function_exists($name)) {
             throw new FunctionExistsException(sprintf(
                 'Function %1$s() already exists. You may redefine it using %2$s::redefineFunction() instead.',
@@ -128,6 +132,10 @@ trait Functions
     {
         if (! function_exists($name)) {
             return $this;
+        }
+
+        if (! Runkit::isAvailable()) {
+            $this->markTestSkipped('deleteFunction() requires Runkit be available, skipping.');
         }
 
         $namespaced = Runkit::makeNamespaced($name);

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -4,7 +4,6 @@ namespace Tests;
 
 use AssertWell\PHPUnitGlobalState\Exceptions\RedefineException;
 use AssertWell\PHPUnitGlobalState\Support\Runkit;
-use PHPUnit\Framework\SkippedTestError;
 
 /**
  * @covers AssertWell\PHPUnitGlobalState\Constants

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests;
 
-use AssertWell\PHPUnitGlobalState\Exceptions\RedefineException;
-use PHPUnit\Framework\SkippedTestError;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
@@ -15,6 +13,9 @@ class FixtureTest extends TestCase
 {
     use SetUpTearDownTrait;
 
+    /**
+     * @var array<string>
+     */
     protected $backupGlobalsBlacklist = [
         'FIXTURE_BEFORE_GLOBAL',
         'FIXTURE_SETUP_GLOBAL',

--- a/tests/GlobalVariablesTest.php
+++ b/tests/GlobalVariablesTest.php
@@ -9,6 +9,9 @@ namespace Tests;
  */
 class GlobalVariablesTest extends TestCase
 {
+    /**
+     * @var array<string>
+     */
     protected $backupGlobalsBlacklist = [
         'setGlobalVariable',
     ];


### PR DESCRIPTION
* Mark tests that use `defineFunction()` or `deleteFunction()` as skipped if Runkit is unavailable (#25)
* Fix coding standards, remove unused namespace imports (#22, props @peter279k)