### PR TITLE
fixing php8.2 deprecation

### DIFF
--- a/src/EnvironmentVariables.php
+++ b/src/EnvironmentVariables.php
@@ -19,7 +19,7 @@ trait EnvironmentVariables
     protected function restoreEnvironmentVariables()
     {
         foreach ($this->environmentVariables as $variable => $value) {
-            putenv(false === $value ? $variable : "${variable}=${value}");
+            putenv(false === $value ? $variable : "{$variable}={$value}");
         }
     }
 
@@ -40,7 +40,7 @@ trait EnvironmentVariables
             $this->environmentVariables[$variable] = getenv($variable);
         }
 
-        putenv(null === $value ? $variable : "${variable}=${value}");
+        putenv(null === $value ? $variable : "{$variable}={$value}");
 
         return $this;
     }


### PR DESCRIPTION
Switching to php 8.2's recommended method of using variables in strings, to resolve:
Deprecated: Using ${var} in strings is deprecated, use {$var} instead