### PR TITLE
replace after annotation with attribute

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,3 +23,9 @@ parameters:
         -
             message: '#Call to an undefined static method \S+#'
             path: tests/Support/RunkitTest.php
+
+        # PHPUnit 10+ attributes not available in earlier versions
+        -
+            message: '#Attribute class PHPUnit\\Framework\\Attributes\\After does not exist\.#'
+            paths:
+                - src/EnvironmentVariables.php

--- a/src/EnvironmentVariables.php
+++ b/src/EnvironmentVariables.php
@@ -12,10 +12,9 @@ trait EnvironmentVariables
     private $environmentVariables = [];
 
     /**
-     * @after
-     *
      * @return void
      */
+    #[\PHPUnit\Framework\Attributes\After]
     protected function restoreEnvironmentVariables()
     {
         foreach ($this->environmentVariables as $variable => $value) {

--- a/src/EnvironmentVariables.php
+++ b/src/EnvironmentVariables.php
@@ -12,6 +12,8 @@ trait EnvironmentVariables
     private $environmentVariables = [];
 
     /**
+     * @after
+     *
      * @return void
      */
     #[\PHPUnit\Framework\Attributes\After]


### PR DESCRIPTION
PHPUnit 11 emits a deprecation warning when using annotations (@after), and they will not work in PHPUnit 12.
However, having both an annotation plus an attribute seems fine. It should be backwards-compatible since annotations are comments in earlier php versions.